### PR TITLE
Adding unstable option to the container at run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ _Make sure to create a **steam.env** file with your Steam user name and password
 You must turn off Steam Guard for this image to work. If someone has a good idea of how to get it to work with Steam Guard, please let me know.
 
 The Starbound game files will be downloaded via steamcmd into the starbound directory. This is to ensure persistence.
+
+##### Unstable
+
+Adding the env variable `STARBOUND_UNSTABLE=true` will run the unstable Starbound version.

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-/steamcmd/steamcmd.sh +@ShutdownOnFailedCommand 1 +@NoPromptForPassword 1 +login $STEAM_USERNAME $STEAM_PASSWORD +force_install_dir /starbound/ +app_update 211820 +quit
+if [ -z "$STARBOUND_UNSTABLE" ]
+then
+  APP_ID="211820"
+else
+  APP_ID="367540"
+fi
+
+/steamcmd/steamcmd.sh +@ShutdownOnFailedCommand 1 +@NoPromptForPassword 1 +login $STEAM_USERNAME $STEAM_PASSWORD +force_install_dir /starbound/ +app_update $APP_ID +quit
 
 cd /starbound/linux64
 


### PR DESCRIPTION
I wanted the option to be able to run the container with the latest unstable build of starbound so I added a env var STARBOUND_UNSTABLE. It defaults to false.
